### PR TITLE
chore(clerk): bot probe pattern implementation to avoid wasting resources on bot scanners

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,22 @@
+import Link from "next/link";
+
+const NotFoundPage = () => {
+    return (
+        <main className="flex min-h-[calc(100vh-4rem)] flex-col items-center justify-center px-4">
+            <div className="text-center">
+                <h1 className="text-7xl font-bold text-foreground">404</h1>
+                <p className="mt-4 text-xl text-foreground/60">
+                    This page doesn't exist.
+                </p>
+                <Link
+                    href="/"
+                    className="mt-8 inline-block rounded-full bg-[#6c47ff] px-6 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
+                >
+                    Go home
+                </Link>
+            </div>
+        </main>
+    );
+};
+
+export default NotFoundPage;

--- a/middleware.ts
+++ b/middleware.ts
@@ -3,7 +3,16 @@ import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 import { createSupabaseMiddleware } from "./lib/supabase/middleware";
 
+const BOT_PROBE_PATTERNS =
+    /^\/(\.env|\.git|\.aws|\.docker|config\/|wp-|admin|phpmy|cgi-bin|\.well-known\/security)/i;
+
 export default clerkMiddleware(async (auth, req: NextRequest) => {
+    const pathname = req.nextUrl.pathname;
+
+    if (BOT_PROBE_PATTERNS.test(pathname)) {
+        return new NextResponse(null, { status: 404 });
+    }
+
     const { userId } = await auth();
 
     // Not signed in → let Clerk handle it


### PR DESCRIPTION
Bots have been scanning app and this makes it clerk run on urls meaning errors can be thrown what will trigger sentry and vercel logs what is a waste of resources so handling it in middleware so it doesn't even more trough code.
Also simple 404 page for someone who access a route that doesn't exist.