### PR TITLE
feat(payments): replace hosted checkout with Lemon Squeezy  overlay

### DIFF
--- a/app/(dashboard)/upgrade/page.tsx
+++ b/app/(dashboard)/upgrade/page.tsx
@@ -4,7 +4,6 @@ import { HugeiconsIcon } from "@hugeicons/react";
 import Link from "next/link";
 import { UpgradeFeatureGrid } from "@/components/upgrade/upgrade-feature-grid";
 import { UpgradePricingSection } from "@/components/upgrade/upgrade-pricing-section";
-import { CHECKOUT_URL } from "@/lib/constants/upgrade";
 import { getEntriesWithInsightsPaginated } from "@/lib/entries/repo";
 import { getTotalInsightsCount } from "@/lib/entry-insights/repo";
 import {
@@ -85,7 +84,7 @@ const UpgradePage = async () => {
                     upgradeProgressInsight={upgradeProgressInsight}
                 />
 
-                <UpgradePricingSection checkoutUrl={CHECKOUT_URL} />
+                <UpgradePricingSection />
             </div>
         </div>
     );

--- a/app/api/payments/checkout/route.ts
+++ b/app/api/payments/checkout/route.ts
@@ -34,6 +34,13 @@ export const POST = async () => {
         );
         checkoutUrl.searchParams.set("checkout[custom][user_id]", userId);
 
+        if (process.env.NODE_ENV === "development") {
+            checkoutUrl.searchParams.set(
+                "checkout[redirect_url]",
+                "http://localhost:3000",
+            );
+        }
+
         return NextResponse.json({ data: { url: checkoutUrl.toString() } });
     } catch (error) {
         console.error("Checkout URL generation failed:", error);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import { ClerkProvider } from "@clerk/nextjs";
 import type { Metadata } from "next";
 import { Libre_Baskerville } from "next/font/google";
 import localFont from "next/font/local";
+import { CheckoutOverlayTest } from "@/components/dev/checkout-overlay-test";
+import { LemonSqueezyProvider } from "@/components/lemon-squeezy-provider";
 import "./globals.css";
 
 const satoshi = localFont({
@@ -53,6 +55,10 @@ const RootLayout = ({
                     className={`${satoshi.variable} ${libreBaskerville.variable} antialiased`}
                 >
                     {children}
+                    <LemonSqueezyProvider />
+                    {process.env.NODE_ENV === "development" && (
+                        <CheckoutOverlayTest />
+                    )}
                 </body>
             </html>
         </ClerkProvider>

--- a/components/dev/checkout-overlay-test.tsx
+++ b/components/dev/checkout-overlay-test.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+const openCheckoutOverlay = (url: string) => {
+    if (window.LemonSqueezy?.Url?.Open) {
+        window.LemonSqueezy.Url.Open(url);
+    } else {
+        window.location.href = url;
+    }
+};
+
+const CheckoutOverlayTest = () => {
+    const [loading, setLoading] = useState(false);
+
+    const handleTest = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch("/api/payments/checkout", {
+                method: "POST",
+            });
+            const json = await res.json();
+            if (json.data?.url) {
+                openCheckoutOverlay(json.data.url);
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    return (
+        <div className="fixed bottom-4 right-4 z-50">
+            <Button
+                size="sm"
+                variant="outline"
+                onClick={handleTest}
+                disabled={loading}
+                className="border-orange-400 text-orange-600 bg-white shadow-md"
+            >
+                {loading ? "Loading..." : "[DEV] Test Checkout Overlay"}
+            </Button>
+        </div>
+    );
+};
+
+export { CheckoutOverlayTest };

--- a/components/lemon-squeezy-provider.tsx
+++ b/components/lemon-squeezy-provider.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Script from "next/script";
+
+const onLemonLoad = () => {
+    window.LemonSqueezy?.Setup({
+        eventHandler: (data: unknown) => {
+            const event = data as { event?: string };
+            if (event.event === "Checkout.Success") {
+                window.location.href = "/entries/new";
+            }
+        },
+    });
+};
+
+const LemonSqueezyProvider = () => (
+    <Script
+        src="https://assets.lemonsqueezy.com/lemon.js"
+        strategy="lazyOnload"
+        onLoad={onLemonLoad}
+    />
+);
+
+export { LemonSqueezyProvider };

--- a/components/settings/upgrade-plan-button.tsx
+++ b/components/settings/upgrade-plan-button.tsx
@@ -16,7 +16,11 @@ const UpgradePlanButton = () => {
             });
             const json = await res.json();
             if (json.data?.url) {
-                window.location.href = json.data.url;
+                if (window.LemonSqueezy?.Url?.Open) {
+                    window.LemonSqueezy.Url.Open(json.data.url);
+                } else {
+                    window.location.href = json.data.url;
+                }
             }
         } finally {
             setLoading(false);

--- a/components/upgrade/upgrade-pricing-section.tsx
+++ b/components/upgrade/upgrade-pricing-section.tsx
@@ -1,52 +1,76 @@
-import Link from "next/link";
+"use client";
+
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 
-interface UpgradePricingSectionProps {
-    checkoutUrl: string;
-}
+const UpgradePricingSection = () => {
+    const [loading, setLoading] = useState(false);
 
-const UpgradePricingSection = ({ checkoutUrl }: UpgradePricingSectionProps) => (
-    <>
-        <div className="my-10 border-t border-border" />
+    const handleCheckout = async () => {
+        setLoading(true);
+        try {
+            const res = await fetch("/api/payments/checkout", {
+                method: "POST",
+            });
+            const json = await res.json();
+            if (json.data?.url) {
+                if (window.LemonSqueezy?.Url?.Open) {
+                    window.LemonSqueezy.Url.Open(json.data.url);
+                } else {
+                    window.location.href = json.data.url;
+                }
+            }
+        } finally {
+            setLoading(false);
+        }
+    };
 
-        <div className="flex flex-col items-center gap-6">
-            <div className="flex gap-4 w-full max-w-md">
-                <div className="flex-1 rounded-xl border border-neutral-200 bg-card px-5 py-4">
-                    <p className="text-xs uppercase tracking-widest text-muted-foreground mb-1">
-                        Monthly
-                    </p>
-                    <p className="font-serif text-3xl italic text-neutral-500">
-                        $10.99
-                    </p>
-                    <p className="text-sm text-muted-foreground">per month</p>
+    return (
+        <>
+            <div className="my-10 border-t border-border" />
+
+            <div className="flex flex-col items-center gap-6">
+                <div className="flex gap-4 w-full max-w-md">
+                    <div className="flex-1 rounded-xl border border-neutral-200 bg-card px-5 py-4">
+                        <p className="text-xs uppercase tracking-widest text-muted-foreground mb-1">
+                            Monthly
+                        </p>
+                        <p className="font-serif text-3xl italic text-neutral-500">
+                            $10.99
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                            per month
+                        </p>
+                    </div>
+                    <div className="relative flex-1 rounded-xl border border-transparent bg-card px-5 py-4 [background:linear-gradient(var(--card),var(--card))_padding-box,linear-gradient(to_right,rgb(148,163,184),rgba(148,163,184,0.9),rgba(251,146,60,0.6))_border-box]">
+                        <span className="absolute -top-2.5 right-3 rounded-full bg-slate-200 border border-slate-400 px-2 py-0.5 text-xs text-slate-500">
+                            Save 25%
+                        </span>
+                        <p className="text-xs uppercase tracking-widest text-muted-foreground mb-1">
+                            Yearly
+                        </p>
+                        <p className="font-serif text-3xl italic text-neutral-500">
+                            $99
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                            $8.25/mo, billed annually
+                        </p>
+                    </div>
                 </div>
-                <div className="relative flex-1 rounded-xl border border-transparent bg-card px-5 py-4 [background:linear-gradient(var(--card),var(--card))_padding-box,linear-gradient(to_right,rgb(148,163,184),rgba(148,163,184,0.9),rgba(251,146,60,0.6))_border-box]">
-                    <span className="absolute -top-2.5 right-3 rounded-full bg-slate-200 border border-slate-400 px-2 py-0.5 text-xs text-slate-500">
-                        Save 25%
-                    </span>
-                    <p className="text-xs uppercase tracking-widest text-muted-foreground mb-1">
-                        Yearly
-                    </p>
-                    <p className="font-serif text-3xl italic text-neutral-500">
-                        $99
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                        $8.25/mo, billed annually
-                    </p>
-                </div>
+                <Button
+                    variant="sunrise"
+                    className="w-full max-w-md font-bold"
+                    onClick={handleCheckout}
+                    disabled={loading}
+                >
+                    {loading ? "Loading..." : "Continue with Pro"}
+                </Button>
+                <p className="text-sm text-muted-foreground">
+                    Cancel anytime. Your entries are always yours.
+                </p>
             </div>
-            <Button
-                asChild
-                variant="sunrise"
-                className="w-full max-w-md font-bold"
-            >
-                <Link href={checkoutUrl}>Continue with Pro</Link>
-            </Button>
-            <p className="text-sm text-muted-foreground">
-                Cancel anytime. Your entries are always yours.
-            </p>
-        </div>
-    </>
-);
+        </>
+    );
+};
 
-export { UpgradePricingSection, type UpgradePricingSectionProps };
+export { UpgradePricingSection };

--- a/types/lemon-squeezy.d.ts
+++ b/types/lemon-squeezy.d.ts
@@ -1,0 +1,10 @@
+declare global {
+    interface Window {
+        LemonSqueezy?: {
+            Url: { Open: (url: string) => void };
+            Setup: (options: { eventHandler: (data: unknown) => void }) => void;
+        };
+    }
+}
+
+export {};


### PR DESCRIPTION
  - Load lemon.js via LemonSqueezyProvider with Checkout.Success handler
  - Redirect to /entries/new after successful payment
  - Update UpgradePlanButton and UpgradePricingSection to open overlay with fallback redirect if script not loaded
  - Add dev-only checkout test button and localhost redirect override
  - Type window.LemonSqueezy global